### PR TITLE
[Feature] 검색창, 검색 시 쿼리로 요청 전송 추가

### DIFF
--- a/src/app/(web)/search/item/page.tsx
+++ b/src/app/(web)/search/item/page.tsx
@@ -1,11 +1,74 @@
+"use client";
+
+import { useState } from "react";
 import Itemfilter from "@/components/search/Item/ItemFilter";
 import ItemFooter from "@/components/search/Item/ItemFooter";
 import ItemResult from "@/components/search/Item/ItemResult";
+import { SearchItemState } from "@/types/search/item/type";
+import { useRouter } from "next/navigation";
+import { SEARCH_ROUTES } from "@/constants/routes";
+import SearchText from "@/components/search/SearchText";
 
 export default function SearchItemPage() {
+  const [searchedKeyword, setSearchedKeyword] = useState<string>("");
+  const [searchItemState, setSearchItemState] = useState<SearchItemState>({
+    searchType: 0,
+    includeOutOfStock: true,
+    branchType: 0,
+    mdLevel: 0,
+    isDirectDelivery: true,
+    sortOrder: 0,
+  });
+  const router = useRouter();
+
+  const searchKeywordChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ): void => {
+    setSearchedKeyword(event.target.value);
+  };
+
+  const searchSubmit = (): void => {
+    if (searchedKeyword) {
+      const query = new URLSearchParams({
+        keyword: searchedKeyword,
+        searchType: searchItemState.searchType.toString(),
+        includeOutOfStock: searchItemState.includeOutOfStock.toString(),
+        branchType: searchItemState.branchType.toString(),
+        mdLevel: searchItemState.mdLevel.toString(),
+        isDirectDelivery: searchItemState.isDirectDelivery.toString(),
+        sortOrder: searchItemState.sortOrder.toString(),
+      }).toString();
+
+      router.push(`${SEARCH_ROUTES.URL.ITEM}?${query}`);
+    }
+  };
+
+  const filterChange = (key: keyof SearchItemState, value: any): void => {
+    setSearchItemState((prevState) => ({
+      ...prevState,
+      [key]: value,
+    }));
+  };
+
+  const filterCheckBoxChange = (key: keyof SearchItemState): void => {
+    setSearchItemState((prevState) => ({
+      ...prevState,
+      [key]: !prevState[key],
+    }));
+  };
+
   return (
     <>
-      <Itemfilter />
+      <SearchText
+        searchedKeyword={searchedKeyword}
+        searchKeywordChange={searchKeywordChange}
+        searchSubmit={searchSubmit}
+      />
+      <Itemfilter
+        searchItemState={searchItemState}
+        filterChange={filterChange}
+        filterCheckBoxChange={filterCheckBoxChange}
+      />
       <ItemResult />
       <ItemFooter />
     </>

--- a/src/app/(web)/search/item/page.tsx
+++ b/src/app/(web)/search/item/page.tsx
@@ -43,14 +43,14 @@ export default function SearchItemPage() {
     }
   };
 
-  const filterChange = (key: keyof SearchItemState, value: any): void => {
+  const changeFilter = (key: keyof SearchItemState, value: any): void => {
     setSearchItemState((prevState) => ({
       ...prevState,
       [key]: value,
     }));
   };
 
-  const filterCheckBoxChange = (key: keyof SearchItemState): void => {
+  const changeCheckBoxFilter = (key: keyof SearchItemState): void => {
     setSearchItemState((prevState) => ({
       ...prevState,
       [key]: !prevState[key],
@@ -66,8 +66,8 @@ export default function SearchItemPage() {
       />
       <Itemfilter
         searchItemState={searchItemState}
-        filterChange={filterChange}
-        filterCheckBoxChange={filterCheckBoxChange}
+        changeFilter={changeFilter}
+        changeCheckBoxFilter={changeCheckBoxFilter}
       />
       <ItemResult />
       <ItemFooter />

--- a/src/components/search/Item/ItemFilter.tsx
+++ b/src/components/search/Item/ItemFilter.tsx
@@ -9,82 +9,66 @@ import {
   SORT_ORDER,
   SearchItemState,
 } from "@/types/search/item/type";
-import { useState } from "react";
+import { FC } from "react";
 
-const Itemfilter = () => {
-  const [searchItemState, setSearchItemState] = useState<SearchItemState>({
-    searchType: 0,
-    includeOutOfStock: true,
-    branchType: 0,
-    mdLevel: 0,
-    isDirectDelivery: true,
-    sortOrder: 0,
-  });
+interface ItemFilterProps {
+  searchItemState: SearchItemState;
+  filterChange: (key: keyof SearchItemState, value: any) => void;
+  filterCheckBoxChange: (key: keyof SearchItemState) => void;
+}
 
-  const itemChange = (key: keyof SearchItemState, value: any): void => {
-    setSearchItemState((prevState) => ({
-      ...prevState,
-      [key]: value,
-    }));
-  };
-
-  const itemCheckBoxChange = (key: keyof SearchItemState): void => {
-    setSearchItemState((prevState) => ({
-      ...prevState,
-      [key]: !prevState[key],
-    }));
-  };
-
+const Itemfilter: FC<ItemFilterProps> = ({
+  searchItemState,
+  filterChange,
+  filterCheckBoxChange,
+}) => {
   return (
-
     <div className="row">
       <div className="col-12 search-group">
         <Radio
           options={SEARCH_TYPE}
           name="searchType"
           selectedValue={searchItemState.searchType}
-          onChange={(value) => itemChange("searchType", value)}
+          onChange={(value) => filterChange("searchType", value)}
         />
       </div>
       <div className="col-12 search-group">
-      <Radio
-        options={MD_LEVEL}
-        name="mdLevel"
-        selectedValue={searchItemState.mdLevel}
-        onChange={(value) => itemChange("mdLevel", value)}
-      />
+        <Radio
+          options={MD_LEVEL}
+          name="mdLevel"
+          selectedValue={searchItemState.mdLevel}
+          onChange={(value) => filterChange("mdLevel", value)}
+        />
       </div>
       <div className="col-12 search-group">
-      <Radio
-        options={SORT_ORDER}
-        name="sortOrder"
-        selectedValue={searchItemState.sortOrder}
-        onChange={(value) => itemChange("sortOrder", value)}
-      />
-      </div>
-
-      <div className="col-12 search-group">
-      <Radio
-        options={BRANCH_TYPE}
-        name="branchType"
-        selectedValue={searchItemState.branchType}
-        onChange={(value) => itemChange("branchType", value)}
-      />
-      </div>
-
-      <div className="col-12 search-group">
-      <Checkbox
-        label="보유"
-        checked={searchItemState.includeOutOfStock}
-        onChange={() => itemCheckBoxChange("includeOutOfStock")}
-      />
+        <Radio
+          options={SORT_ORDER}
+          name="sortOrder"
+          selectedValue={searchItemState.sortOrder}
+          onChange={(value) => filterChange("sortOrder", value)}
+        />
       </div>
       <div className="col-12 search-group">
-      <Checkbox
-        label="직배송"
-        checked={searchItemState.isDirectDelivery}
-        onChange={() => itemCheckBoxChange("isDirectDelivery")}
-      />
+        <Radio
+          options={BRANCH_TYPE}
+          name="branchType"
+          selectedValue={searchItemState.branchType}
+          onChange={(value) => filterChange("branchType", value)}
+        />
+      </div>
+      <div className="col-12 search-group">
+        <Checkbox
+          label="보유"
+          checked={searchItemState.includeOutOfStock}
+          onChange={() => filterCheckBoxChange("includeOutOfStock")}
+        />
+      </div>
+      <div className="col-12 search-group">
+        <Checkbox
+          label="직배송"
+          checked={searchItemState.isDirectDelivery}
+          onChange={() => filterCheckBoxChange("isDirectDelivery")}
+        />
       </div>
     </div>
   );

--- a/src/components/search/Item/ItemFilter.tsx
+++ b/src/components/search/Item/ItemFilter.tsx
@@ -2,6 +2,7 @@
 
 import Checkbox from "@/components/common/CheckBox";
 import Radio from "@/components/common/Radio";
+import { SEARCH } from "@/constants/search";
 import {
   BRANCH_TYPE,
   MD_LEVEL,
@@ -13,61 +14,77 @@ import { FC } from "react";
 
 interface ItemFilterProps {
   searchItemState: SearchItemState;
-  filterChange: (key: keyof SearchItemState, value: any) => void;
-  filterCheckBoxChange: (key: keyof SearchItemState) => void;
+  changeFilter: (key: keyof SearchItemState, value: any) => void;
+  changeCheckBoxFilter: (key: keyof SearchItemState) => void;
 }
 
 const Itemfilter: FC<ItemFilterProps> = ({
   searchItemState,
-  filterChange,
-  filterCheckBoxChange,
+  changeFilter,
+  changeCheckBoxFilter,
 }) => {
   return (
     <div className="row">
       <div className="col-12 search-group">
         <Radio
           options={SEARCH_TYPE}
-          name="searchType"
+          name={SEARCH.SEARCH_TYPE}
           selectedValue={searchItemState.searchType}
-          onChange={(value) => filterChange("searchType", value)}
+          onChange={(value) =>
+            changeFilter(SEARCH.SEARCH_TYPE as keyof SearchItemState, value)
+          }
         />
       </div>
       <div className="col-12 search-group">
         <Radio
           options={MD_LEVEL}
-          name="mdLevel"
+          name={SEARCH.MD_LEVEL}
           selectedValue={searchItemState.mdLevel}
-          onChange={(value) => filterChange("mdLevel", value)}
+          onChange={(value) =>
+            changeFilter(SEARCH.MD_LEVEL as keyof SearchItemState, value)
+          }
         />
       </div>
       <div className="col-12 search-group">
         <Radio
           options={SORT_ORDER}
-          name="sortOrder"
+          name={SEARCH.SORT_ORDER}
           selectedValue={searchItemState.sortOrder}
-          onChange={(value) => filterChange("sortOrder", value)}
+          onChange={(value) =>
+            changeFilter(SEARCH.SORT_ORDER as keyof SearchItemState, value)
+          }
         />
       </div>
       <div className="col-12 search-group">
         <Radio
           options={BRANCH_TYPE}
-          name="branchType"
+          name={SEARCH.BRANCH_TYPE}
           selectedValue={searchItemState.branchType}
-          onChange={(value) => filterChange("branchType", value)}
+          onChange={(value) =>
+            changeFilter(SEARCH.BRANCH_TYPE as keyof SearchItemState, value)
+          }
         />
       </div>
       <div className="col-12 search-group">
         <Checkbox
           label="보유"
           checked={searchItemState.includeOutOfStock}
-          onChange={() => filterCheckBoxChange("includeOutOfStock")}
+          onChange={() =>
+            changeCheckBoxFilter(
+              SEARCH.INCLUDE_OUT_OF_STOCK as keyof SearchItemState
+            )
+          }
         />
       </div>
       <div className="col-12 search-group">
         <Checkbox
           label="직배송"
           checked={searchItemState.isDirectDelivery}
-          onChange={() => filterCheckBoxChange("isDirectDelivery")}
+          onChange={() =>
+            changeCheckBoxFilter(
+              SEARCH.IS_DIRECT_DELIVERY as keyof SearchItemState
+            )
+          }
         />
       </div>
     </div>

--- a/src/components/search/Item/ItemFilter.tsx
+++ b/src/components/search/Item/ItemFilter.tsx
@@ -23,70 +23,67 @@ const Itemfilter: FC<ItemFilterProps> = ({
   changeFilter,
   changeCheckBoxFilter,
 }) => {
+  const radioConfigs = [
+    {
+      options: SEARCH_TYPE,
+      name: SEARCH.SEARCH_TYPE,
+      selectedValue: searchItemState.searchType,
+    },
+    {
+      options: MD_LEVEL,
+      name: SEARCH.MD_LEVEL,
+      selectedValue: searchItemState.mdLevel,
+    },
+    {
+      options: SORT_ORDER,
+      name: SEARCH.SORT_ORDER,
+      selectedValue: searchItemState.sortOrder,
+    },
+    {
+      options: BRANCH_TYPE,
+      name: SEARCH.BRANCH_TYPE,
+      selectedValue: searchItemState.branchType,
+    },
+  ];
+
+  const checkboxConfigs = [
+    {
+      label: "보유",
+      checked: searchItemState.includeOutOfStock,
+      name: SEARCH.INCLUDE_OUT_OF_STOCK,
+    },
+    {
+      label: "직배송",
+      checked: searchItemState.isDirectDelivery,
+      name: SEARCH.IS_DIRECT_DELIVERY,
+    },
+  ];
   return (
     <div className="row">
-      <div className="col-12 search-group">
-        <Radio
-          options={SEARCH_TYPE}
-          name={SEARCH.SEARCH_TYPE}
-          selectedValue={searchItemState.searchType}
-          onChange={(value) =>
-            changeFilter(SEARCH.SEARCH_TYPE as keyof SearchItemState, value)
-          }
-        />
-      </div>
-      <div className="col-12 search-group">
-        <Radio
-          options={MD_LEVEL}
-          name={SEARCH.MD_LEVEL}
-          selectedValue={searchItemState.mdLevel}
-          onChange={(value) =>
-            changeFilter(SEARCH.MD_LEVEL as keyof SearchItemState, value)
-          }
-        />
-      </div>
-      <div className="col-12 search-group">
-        <Radio
-          options={SORT_ORDER}
-          name={SEARCH.SORT_ORDER}
-          selectedValue={searchItemState.sortOrder}
-          onChange={(value) =>
-            changeFilter(SEARCH.SORT_ORDER as keyof SearchItemState, value)
-          }
-        />
-      </div>
-      <div className="col-12 search-group">
-        <Radio
-          options={BRANCH_TYPE}
-          name={SEARCH.BRANCH_TYPE}
-          selectedValue={searchItemState.branchType}
-          onChange={(value) =>
-            changeFilter(SEARCH.BRANCH_TYPE as keyof SearchItemState, value)
-          }
-        />
-      </div>
-      <div className="col-12 search-group">
-        <Checkbox
-          label="보유"
-          checked={searchItemState.includeOutOfStock}
-          onChange={() =>
-            changeCheckBoxFilter(
-              SEARCH.INCLUDE_OUT_OF_STOCK as keyof SearchItemState
-            )
-          }
-        />
-      </div>
-      <div className="col-12 search-group">
-        <Checkbox
-          label="직배송"
-          checked={searchItemState.isDirectDelivery}
-          onChange={() =>
-            changeCheckBoxFilter(
-              SEARCH.IS_DIRECT_DELIVERY as keyof SearchItemState
-            )
-          }
-        />
-      </div>
+      {radioConfigs.map((config) => (
+        <div className="col-12 search-group" key={config.name}>
+          <Radio
+            options={config.options}
+            name={config.name}
+            selectedValue={config.selectedValue}
+            onChange={(value) =>
+              changeFilter(config.name as keyof SearchItemState, value)
+            }
+          />
+        </div>
+      ))}
+
+      {checkboxConfigs.map((config) => (
+        <div className="col-12 search-group" key={config.name}>
+          <Checkbox
+            label={config.label}
+            checked={config.checked}
+            onChange={() =>
+              changeCheckBoxFilter(config.name as keyof SearchItemState)
+            }
+          />
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/components/search/SearchText.tsx
+++ b/src/components/search/SearchText.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { FC } from "react";
+
+interface SearchTextProps {
+  searchedKeyword: string;
+  searchKeywordChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  searchSubmit: () => void;
+}
+
+const SearchText: FC<SearchTextProps> = ({ searchedKeyword, searchKeywordChange, searchSubmit }) => {
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (event.key === "Enter") {
+        searchSubmit();
+    }
+  };
+
+  return (
+    <div className="d-flex justify-content-center">
+      <div className="input-group">
+        <input
+          className="form-control"
+          placeholder="검색어를 입력해 주세요"
+          value={searchedKeyword}
+          onChange={searchKeywordChange}
+          onKeyDown={handleKeyDown}
+          autoFocus
+        />
+        <button className="btn btn-primary" type="button" onClick={searchSubmit}>
+          찾기
+        </button>
+        <button className="btn btn-secondary">외부입력(POS)</button>
+        <button className="btn btn-secondary">Q...</button>
+      </div>
+    </div>
+  );
+}
+
+export default SearchText;

--- a/src/constants/key.ts
+++ b/src/constants/key.ts
@@ -1,3 +1,6 @@
 export enum CookieKey {
   User = "user",
 }
+
+
+

--- a/src/constants/search.ts
+++ b/src/constants/search.ts
@@ -1,0 +1,8 @@
+export const SEARCH = {
+  SEARCH_TYPE: "searchType",
+  MD_LEVEL: "mdLevel",
+  SORT_ORDER: "sortOrder",
+  BRANCH_TYPE: "branchType",
+  INCLUDE_OUT_OF_STOCK: "includeOutOfStock",
+  IS_DIRECT_DELIVERY: "isDirectDelivery",
+};


### PR DESCRIPTION
 ## 어떤 이유로 PR을 하셨나요?
 * [x]  feature 병합
 * [ ]  버그 수정
 * [ ]  코드 개선
 * [ ]  기타(아래에 자세한 내용을 기입해주세요)
 
 ## 스크린샷 및 세부 내용 - 왜 해당 PR이 필요한지 자세하게 설명해주세요
![image](https://github.com/dh413/ThankYouFront2/assets/148740246/64283138-6862-403b-88d0-ae75646786e1)
검색, 필터 컴포넌트에 상태를 props로 전달하여 각 컴포넌트의 조건에 따라 
상위 컴포넌트인 SearchItemPage에 상태가 업데이트 되어 검색결과에 반영됩니다.


과제에선 SearchText 컴포넌트 내부에서 ItemFilter 컴포넌트를 호출했지만
SearchItemPage 에서 각각의 컴포넌트로 상태를 전달하였습니다.
