### PR TITLE
[Refactor] API호출 ItemResult -> ItemMain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "next": "14.2.3",
         "react": "^18",
         "react-dom": "^18",
+        "react-spinners": "^0.13.8",
         "recoil": "^0.7.7"
       },
       "devDependencies": {
@@ -3873,6 +3874,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/react-spinners": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.8.tgz",
+      "integrity": "sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "next": "14.2.3",
     "react": "^18",
     "react-dom": "^18",
+    "react-spinners": "^0.13.8",
     "recoil": "^0.7.7"
   },
   "devDependencies": {

--- a/src/components/search/Item/ItemMain.tsx
+++ b/src/components/search/Item/ItemMain.tsx
@@ -129,7 +129,6 @@ export default function ItemMain() {
       isDirectDelivery: isDirectDelivery === "true",
       sortOrder: sortOrder ? parseInt(sortOrder, 10) : 0,
     });
-    console.log("여기탈텐데");
     setIsSearch(true);
   }, [
     keyword,
@@ -158,11 +157,18 @@ export default function ItemMain() {
           <ClipLoader size={50} color={"#123abc"} loading={isLoading} />
         </div>
       ) : (
-        <ItemResult
-          searchResult={searchResult}
-          errorMsg={errorMsg}
-          clickItemInfo={clickItemInfo}
-        />
+        <>
+          {searchResult && searchResult.data && searchResult.data.length > 0 ? (
+            <ItemResult
+              searchResult={searchResult}
+              clickItemInfo={clickItemInfo}
+            />
+          ) : (
+            <div className="text-center mt-3">
+              {errorMsg ?? "검색결과 없음"}
+            </div>
+          )}
+        </>
       )}
       <ItemFooter selectedItem={selectedItem} resultCount={resultCount} />
     </>

--- a/src/components/search/Item/ItemMain.tsx
+++ b/src/components/search/Item/ItemMain.tsx
@@ -60,9 +60,7 @@ export default function ItemMain() {
         isDirectDelivery: searchItemState.isDirectDelivery.toString(),
         sortOrder: searchItemState.sortOrder.toString(),
       }).toString();
-
       setIsSearching(true);
-
       router.push(`${SEARCH_ROUTES.URL.ITEM}?${query}`);
     }
   };

--- a/src/components/search/Item/ItemMain.tsx
+++ b/src/components/search/Item/ItemMain.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Itemfilter from "@/components/search/Item/ItemFilter";
 import ItemFooter from "@/components/search/Item/ItemFooter";
 import ItemResult from "@/components/search/Item/ItemResult";
@@ -10,6 +10,11 @@ import SearchText from "@/components/search/SearchText";
 import { useRouter, useSearchParams } from "next/navigation";
 import { SEARCH } from "@/constants/search";
 import { SearchResultDto } from "@/types/search/dtos";
+import useGetSearchResults from "@/hooks/search/item/useGetSearchResults";
+import { useRecoilValue } from "recoil";
+import { operatorCodeState } from "@/recoil/search";
+import { SearchData } from "@/types/search/common/type";
+import { ClipLoader } from "react-spinners";
 
 export default function ItemMain() {
   const [searchedKeyword, setSearchedKeyword] = useState<string>("");
@@ -25,6 +30,7 @@ export default function ItemMain() {
     null
   );
   const [resultCount, setResultCount] = useState<number>(0);
+  const [isSearch, setIsSearch] = useState<boolean>(false);
 
   const router = useRouter();
   const params = useSearchParams();
@@ -54,9 +60,13 @@ export default function ItemMain() {
         sortOrder: searchItemState.sortOrder.toString(),
       }).toString();
 
+      setIsSearch(true);
+
       router.push(`${SEARCH_ROUTES.URL.ITEM}?${query}`);
     }
   };
+
+  const operatorCode = useRecoilValue(operatorCodeState) ?? "";
 
   const changeFilter = (key: keyof SearchItemState, value: any): void => {
     setSearchItemState((prevState) => ({
@@ -75,6 +85,39 @@ export default function ItemMain() {
   const clickItemInfo = (item: SearchResultDto) => {
     setSelectedItem(item);
   };
+  const searchData: SearchData = useMemo(
+    () => ({
+      searchType: parseInt(searchType.toString(), 10),
+      operatorCode,
+      sortOrder: parseInt(sortOrder.toString(), 10),
+      branchType: parseInt(branchType.toString(), 10),
+      includeOutOfStock: includeOutOfStock.toString(),
+      mdLevel: parseInt(mdLevel.toString(), 10),
+      isDirectDelivery: isDirectDelivery.toString(),
+      searchValue: keyword,
+    }),
+    [
+      searchType,
+      operatorCode,
+      keyword,
+      sortOrder,
+      branchType,
+      includeOutOfStock,
+      mdLevel,
+      isDirectDelivery,
+    ]
+  );
+
+  const { searchResult, isLoading, errorMsg } = useGetSearchResults(
+    searchData,
+    isSearch
+  );
+
+  useEffect(() => {
+    if (searchResult?.data) {
+      setResultCount(searchResult?.data.length);
+    }
+  }, [searchResult?.data]);
 
   useEffect(() => {
     setSearchedKeyword(keyword);
@@ -86,6 +129,8 @@ export default function ItemMain() {
       isDirectDelivery: isDirectDelivery === "true",
       sortOrder: sortOrder ? parseInt(sortOrder, 10) : 0,
     });
+    console.log("여기탈텐데");
+    setIsSearch(true);
   }, [
     keyword,
     searchType,
@@ -108,10 +153,17 @@ export default function ItemMain() {
         changeFilter={changeFilter}
         changeCheckBoxFilter={changeCheckBoxFilter}
       />
-      <ItemResult
-        clickItemInfo={clickItemInfo}
-        setResultCount={setResultCount}
-      />
+      {isSearch && isLoading ? (
+        <div style={{ textAlign: "center", marginTop: "20px" }}>
+          <ClipLoader size={50} color={"#123abc"} loading={isLoading} />
+        </div>
+      ) : (
+        <ItemResult
+          searchResult={searchResult}
+          errorMsg={errorMsg}
+          clickItemInfo={clickItemInfo}
+        />
+      )}
       <ItemFooter selectedItem={selectedItem} resultCount={resultCount} />
     </>
   );

--- a/src/components/search/Item/ItemMain.tsx
+++ b/src/components/search/Item/ItemMain.tsx
@@ -41,6 +41,7 @@ export default function ItemMain() {
   const isDirectDelivery = params.get(SEARCH.IS_DIRECT_DELIVERY) ?? "true";
   const sortOrder = params.get(SEARCH.SORT_ORDER) ?? 0;
   const mdLevel = params.get(SEARCH.MD_LEVEL) ?? 0;
+  const operatorCode = useRecoilValue(operatorCodeState) ?? "";
 
   const searchKeywordChange = (
     event: React.ChangeEvent<HTMLInputElement>
@@ -65,8 +66,6 @@ export default function ItemMain() {
       router.push(`${SEARCH_ROUTES.URL.ITEM}?${query}`);
     }
   };
-
-  const operatorCode = useRecoilValue(operatorCodeState) ?? "";
 
   const changeFilter = (key: keyof SearchItemState, value: any): void => {
     setSearchItemState((prevState) => ({

--- a/src/components/search/Item/ItemMain.tsx
+++ b/src/components/search/Item/ItemMain.tsx
@@ -30,7 +30,7 @@ export default function ItemMain() {
     null
   );
   const [resultCount, setResultCount] = useState<number>(0);
-  const [isSearch, setIsSearch] = useState<boolean>(false);
+  const [isSearching, setIsSearching] = useState<boolean>(false);
 
   const router = useRouter();
   const params = useSearchParams();
@@ -60,7 +60,7 @@ export default function ItemMain() {
         sortOrder: searchItemState.sortOrder.toString(),
       }).toString();
 
-      setIsSearch(true);
+      setIsSearching(true);
 
       router.push(`${SEARCH_ROUTES.URL.ITEM}?${query}`);
     }
@@ -110,7 +110,7 @@ export default function ItemMain() {
 
   const { searchResult, isLoading, errorMsg } = useGetSearchResults(
     searchData,
-    isSearch
+    isSearching
   );
 
   useEffect(() => {
@@ -129,7 +129,7 @@ export default function ItemMain() {
       isDirectDelivery: isDirectDelivery === "true",
       sortOrder: sortOrder ? parseInt(sortOrder, 10) : 0,
     });
-    setIsSearch(true);
+    setIsSearching(true);
   }, [
     keyword,
     searchType,
@@ -152,7 +152,7 @@ export default function ItemMain() {
         changeFilter={changeFilter}
         changeCheckBoxFilter={changeCheckBoxFilter}
       />
-      {isSearch && isLoading ? (
+      {isSearching && isLoading ? (
         <div style={{ textAlign: "center", marginTop: "20px" }}>
           <ClipLoader size={50} color={"#123abc"} loading={isLoading} />
         </div>

--- a/src/components/search/Item/ItemMain.tsx
+++ b/src/components/search/Item/ItemMain.tsx
@@ -126,7 +126,16 @@ export default function ItemMain() {
       isDirectDelivery: isDirectDelivery === "true",
       sortOrder: sortOrder ? parseInt(sortOrder, 10) : 0,
     });
-    setIsSearching(true);
+    setIsSearching(
+      !!(
+        keyword &&
+        includeOutOfStock &&
+        branchType &&
+        mdLevel &&
+        isDirectDelivery &&
+        sortOrder
+      )
+    );
   }, [
     keyword,
     searchType,
@@ -149,21 +158,28 @@ export default function ItemMain() {
         changeFilter={changeFilter}
         changeCheckBoxFilter={changeCheckBoxFilter}
       />
-      {isSearching && isLoading ? (
-        <div className="text-center mt-3">
-          <ClipLoader size={50} color={"#123abc"} loading={isLoading} />
-        </div>
-      ) : (
+
+      {isSearching && (
         <>
-          {searchResult && searchResult.data && searchResult.data.length > 0 ? (
-            <ItemResult
-              searchResult={searchResult}
-              clickItemInfo={clickItemInfo}
-            />
-          ) : (
+          {isSearching && isLoading ? (
             <div className="text-center mt-3">
-              {errorMsg ?? "검색결과 없음"}
+              <ClipLoader size="50" color="#123abc" loading={isLoading} />
             </div>
+          ) : (
+            <>
+              {searchResult &&
+              searchResult.data &&
+              searchResult.data.length > 0 ? (
+                <ItemResult
+                  searchResult={searchResult}
+                  clickItemInfo={clickItemInfo}
+                />
+              ) : (
+                <div className="text-center mt-3">
+                  {errorMsg ?? "검색결과 없음"}
+                </div>
+              )}
+            </>
           )}
         </>
       )}

--- a/src/components/search/Item/ItemMain.tsx
+++ b/src/components/search/Item/ItemMain.tsx
@@ -150,7 +150,7 @@ export default function ItemMain() {
         changeCheckBoxFilter={changeCheckBoxFilter}
       />
       {isSearching && isLoading ? (
-        <div style={{ textAlign: "center", marginTop: "20px" }}>
+        <div className="text-center mt-3">
           <ClipLoader size={50} color={"#123abc"} loading={isLoading} />
         </div>
       ) : (

--- a/src/components/search/Item/ItemMain.tsx
+++ b/src/components/search/Item/ItemMain.tsx
@@ -30,8 +30,8 @@ export default function ItemMain() {
     null
   );
   const [resultCount, setResultCount] = useState<number>(0);
-  const [isSearching, setIsSearching] = useState<boolean>(false);
 
+  const [isChangeParam, setIsChangeParam] = useState<boolean>(false);
   const router = useRouter();
   const params = useSearchParams();
   const keyword = params.get(SEARCH.KEYWORD) ?? "";
@@ -60,7 +60,6 @@ export default function ItemMain() {
         isDirectDelivery: searchItemState.isDirectDelivery.toString(),
         sortOrder: searchItemState.sortOrder.toString(),
       }).toString();
-      setIsSearching(true);
       router.push(`${SEARCH_ROUTES.URL.ITEM}?${query}`);
     }
   };
@@ -105,16 +104,7 @@ export default function ItemMain() {
     ]
   );
 
-  const { searchResult, isLoading, errorMsg } = useGetSearchResults(
-    searchData,
-    isSearching
-  );
-
-  useEffect(() => {
-    if (searchResult?.data) {
-      setResultCount(searchResult?.data.length);
-    }
-  }, [searchResult?.data]);
+  const { searchResult, isLoading, errorMsg } = useGetSearchResults(searchData);
 
   useEffect(() => {
     setSearchedKeyword(keyword);
@@ -126,7 +116,7 @@ export default function ItemMain() {
       isDirectDelivery: isDirectDelivery === "true",
       sortOrder: sortOrder ? parseInt(sortOrder, 10) : 0,
     });
-    setIsSearching(
+    setIsChangeParam(
       !!(
         keyword &&
         includeOutOfStock &&
@@ -144,7 +134,14 @@ export default function ItemMain() {
     isDirectDelivery,
     sortOrder,
     mdLevel,
+    setIsChangeParam,
   ]);
+
+  useEffect(() => {
+    if (searchResult?.data) {
+      setResultCount(searchResult?.data.length);
+    }
+  }, [searchResult?.data]);
 
   return (
     <>
@@ -158,31 +155,29 @@ export default function ItemMain() {
         changeFilter={changeFilter}
         changeCheckBoxFilter={changeCheckBoxFilter}
       />
-
-      {isSearching && (
+      {isChangeParam && (
         <>
-          {isSearching && isLoading ? (
+          {isLoading ? (
             <div className="text-center mt-3">
               <ClipLoader size={50} color="#123abc" loading={isLoading} />
             </div>
           ) : (
             <>
-              {searchResult &&
-              searchResult.data &&
-              searchResult.data.length > 0 ? (
+              {searchResult?.data.length ? (
                 <ItemResult
                   searchResult={searchResult}
                   clickItemInfo={clickItemInfo}
                 />
               ) : (
                 <div className="text-center mt-3">
-                  {errorMsg ?? "검색결과 없음"}
+                  {errorMsg ?? "검색결과가 없습니다."}
                 </div>
               )}
             </>
           )}
         </>
       )}
+
       <ItemFooter selectedItem={selectedItem} resultCount={resultCount} />
     </>
   );

--- a/src/components/search/Item/ItemMain.tsx
+++ b/src/components/search/Item/ItemMain.tsx
@@ -163,7 +163,7 @@ export default function ItemMain() {
         <>
           {isSearching && isLoading ? (
             <div className="text-center mt-3">
-              <ClipLoader size="50" color="#123abc" loading={isLoading} />
+              <ClipLoader size={50} color="#123abc" loading={isLoading} />
             </div>
           ) : (
             <>

--- a/src/components/search/Item/ItemResult.tsx
+++ b/src/components/search/Item/ItemResult.tsx
@@ -11,12 +11,7 @@ import { SearchData } from "@/types/search/common/type";
 const ItemResult: React.FC<SearchResultProps> = ({
   clickItemInfo,
   searchResult,
-  errorMsg,
 }) => {
-  if (errorMsg) {
-    console.log(errorMsg);
-    return false;
-  }
   if (!searchResult?.data.length) {
     console.log("검색결과값 없음");
     return null;

--- a/src/components/search/Item/ItemResult.tsx
+++ b/src/components/search/Item/ItemResult.tsx
@@ -10,59 +10,16 @@ import { SearchData } from "@/types/search/common/type";
 
 const ItemResult: React.FC<SearchResultProps> = ({
   clickItemInfo,
-  setResultCount,
+  searchResult,
+  errorMsg,
 }) => {
-  const params = useSearchParams();
-  const keyword = params.get(SEARCH.KEYWORD) ?? "";
-  const searchType = params.get(SEARCH.SEARCH_TYPE) ?? "";
-  const includeOutOfStock = params.get(SEARCH.INCLUDE_OUT_OF_STOCK) ?? "";
-  const branchType = params.get(SEARCH.BRANCH_TYPE) ?? "";
-  const isDirectDelivery = params.get(SEARCH.IS_DIRECT_DELIVERY) ?? "";
-  const sortOrder = params.get(SEARCH.SORT_ORDER) ?? "";
-  const mdLevel = params.get(SEARCH.MD_LEVEL) ?? "";
-  const operatorCode = useRecoilValue(operatorCodeState) ?? "";
-
-  const searchData: SearchData = useMemo(
-    () => ({
-      searchType,
-      operatorCode,
-      sortOrder,
-      branchType,
-      includeOutOfStock,
-      mdLevel,
-      isDirectDelivery,
-      searchValue: keyword,
-    }),
-    [
-      searchType,
-      operatorCode,
-      keyword,
-      sortOrder,
-      branchType,
-      includeOutOfStock,
-      mdLevel,
-      isDirectDelivery,
-    ]
-  );
-
-  const { searchResult, isLoading, error } = useGetSearchResults(searchData);
-
-  useEffect(() => {
-    if (searchResult?.data) {
-      setResultCount(searchResult.data.length);
-    }
-  }, [searchResult, setResultCount]);
-
+  if (errorMsg) {
+    console.log(errorMsg);
+    return false;
+  }
   if (!searchResult?.data.length) {
+    console.log("검색결과값 없음");
     return null;
-  }
-
-  if (isLoading) {
-    return <div>검색중</div>;
-  }
-
-  if (error) {
-    return <div>Error: {error}</div>;
   }
 
   return (

--- a/src/components/search/Item/ItemResult.tsx
+++ b/src/components/search/Item/ItemResult.tsx
@@ -1,22 +1,10 @@
-import { useEffect, useMemo } from "react";
-import useGetSearchResults from "@/hooks/search/item/useGetSearchResults";
-import { operatorCodeState } from "@/recoil/search";
 import { COLUMN_TITLES, SearchResultProps } from "@/types/search/item/type";
-import { useSearchParams } from "next/navigation";
-import { useRecoilValue } from "recoil";
 import { SearchResultDto } from "@/types/search/dtos";
-import { SEARCH } from "@/constants/search";
-import { SearchData } from "@/types/search/common/type";
 
 const ItemResult: React.FC<SearchResultProps> = ({
   clickItemInfo,
   searchResult,
 }) => {
-  if (!searchResult?.data.length) {
-    console.log("검색결과값 없음");
-    return null;
-  }
-
   return (
     <div>
       <div className="d-flex bg-light p-2">

--- a/src/hooks/search/item/useGetSearchResults.tsx
+++ b/src/hooks/search/item/useGetSearchResults.tsx
@@ -3,17 +3,19 @@ import { SearchData } from "@/types/search/common/type";
 import { SearchResultDto } from "@/types/search/dtos";
 import { useState, useEffect, useCallback } from "react";
 
-const useGetSearchResults = (searchData: SearchData) => {
+const useGetSearchResults = (searchData: SearchData, isSearch: boolean) => {
   const [searchResult, setSearchResult] = useState<SearchResultDto | null>(
     null
   );
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [error, setError] = useState<string | null>(null);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   const fetchSearchResults = useCallback(async () => {
+    if (!isSearch) return;
+
     try {
       setIsLoading(true);
-      setError(null);
+      setErrorMsg(null);
 
       const response = await fetch(API_ROUTES.SEARCH_ITEM, {
         method: "POST",
@@ -30,17 +32,17 @@ const useGetSearchResults = (searchData: SearchData) => {
       const data = await response.json();
       setSearchResult(data);
     } catch (error) {
-      setError("API에러");
+      setErrorMsg("API에러");
     } finally {
       setIsLoading(false);
     }
-  }, [searchData]);
+  }, [searchData, isSearch]);
 
   useEffect(() => {
     fetchSearchResults();
   }, [searchData, fetchSearchResults]);
 
-  return { searchResult, isLoading, error };
+  return { searchResult, isLoading, errorMsg };
 };
 
 export default useGetSearchResults;

--- a/src/hooks/search/item/useGetSearchResults.tsx
+++ b/src/hooks/search/item/useGetSearchResults.tsx
@@ -3,18 +3,15 @@ import { SearchData } from "@/types/search/common/type";
 import { SearchResultDto } from "@/types/search/dtos";
 import { useState, useEffect, useCallback } from "react";
 
-const useGetSearchResults = (searchData: SearchData, isSearching: boolean) => {
+const useGetSearchResults = (searchData: SearchData) => {
   const [searchResult, setSearchResult] = useState<SearchResultDto | null>(
     null
   );
+
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   const fetchSearchResults = useCallback(async () => {
-    if (!isSearching) {
-      return;
-    }
-
     try {
       setIsLoading(true);
       setErrorMsg(null);
@@ -32,13 +29,14 @@ const useGetSearchResults = (searchData: SearchData, isSearching: boolean) => {
       }
 
       const data = await response.json();
+
       setSearchResult(data);
     } catch (error) {
       setErrorMsg("API에러");
     } finally {
       setIsLoading(false);
     }
-  }, [searchData, isSearching]);
+  }, [searchData]);
 
   useEffect(() => {
     fetchSearchResults();

--- a/src/hooks/search/item/useGetSearchResults.tsx
+++ b/src/hooks/search/item/useGetSearchResults.tsx
@@ -11,7 +11,9 @@ const useGetSearchResults = (searchData: SearchData, isSearching: boolean) => {
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   const fetchSearchResults = useCallback(async () => {
-    if (!isSearching) return;
+    if (!isSearching) {
+      return;
+    }
 
     try {
       setIsLoading(true);

--- a/src/hooks/search/item/useGetSearchResults.tsx
+++ b/src/hooks/search/item/useGetSearchResults.tsx
@@ -36,7 +36,7 @@ const useGetSearchResults = (searchData: SearchData, isSearching: boolean) => {
     } finally {
       setIsLoading(false);
     }
-  }, [searchData, isSearch]);
+  }, [searchData, isSearching]);
 
   useEffect(() => {
     fetchSearchResults();

--- a/src/hooks/search/item/useGetSearchResults.tsx
+++ b/src/hooks/search/item/useGetSearchResults.tsx
@@ -3,7 +3,7 @@ import { SearchData } from "@/types/search/common/type";
 import { SearchResultDto } from "@/types/search/dtos";
 import { useState, useEffect, useCallback } from "react";
 
-const useGetSearchResults = (searchData: SearchData, isSearch: boolean) => {
+const useGetSearchResults = (searchData: SearchData, isSearching: boolean) => {
   const [searchResult, setSearchResult] = useState<SearchResultDto | null>(
     null
   );
@@ -11,7 +11,7 @@ const useGetSearchResults = (searchData: SearchData, isSearch: boolean) => {
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   const fetchSearchResults = useCallback(async () => {
-    if (!isSearch) return;
+    if (!isSearching) return;
 
     try {
       setIsLoading(true);

--- a/src/types/search/common/type.ts
+++ b/src/types/search/common/type.ts
@@ -12,14 +12,13 @@ export interface RadioProps {
   selectedValue: number;
   onChange: (value: number) => void;
 }
-
 export interface SearchData {
   searchValue: string;
-  searchType: string;
+  searchType: number;
   operatorCode: string;
-  sortOrder: string;
-  branchType: string;
+  sortOrder: number;
+  branchType: number;
   includeOutOfStock: string;
-  mdLevel: string;
+  mdLevel: number;
   isDirectDelivery: string;
 }

--- a/src/types/search/item/type.ts
+++ b/src/types/search/item/type.ts
@@ -115,7 +115,6 @@ export const COLUMN_TITLES: { [key: string]: string } = {
 export interface SearchResultProps {
   clickItemInfo: (item: SearchResultDto) => void;
   searchResult: SearchResultDto | null;
-  errorMsg: string | null;
 }
 export interface ItemFooterProps {
   selectedItem: SearchResultDto | null;

--- a/src/types/search/item/type.ts
+++ b/src/types/search/item/type.ts
@@ -114,7 +114,8 @@ export const COLUMN_TITLES: { [key: string]: string } = {
 
 export interface SearchResultProps {
   clickItemInfo: (item: SearchResultDto) => void;
-  setResultCount: (count: number) => void;
+  searchResult: SearchResultDto | null;
+  errorMsg: string | null;
 }
 export interface ItemFooterProps {
   selectedItem: SearchResultDto | null;


### PR DESCRIPTION
 ## 어떤 이유로 PR을 하셨나요?
 * [ ]  feature 병합
 * [ ]  버그 수정
 * [x]  코드 개선
 * [ ]  기타(아래에 자세한 내용을 기입해주세요)
 
 ## 스크린샷 및 세부 내용 - 왜 해당 PR이 필요한지 자세하게 설명해주세요

ItemResult컴포넌트에 API호출하는 기능이 있었는데
기존 
ItemMain ->  SearchText
ItemMain ->  ItemFilter
ItemMain <->  ItemResult (API결과값 부모컴포넌트로 전송)
ItemMain ->  ItemFooter

변경
ItemMain ->  SearchText
ItemMain ->  ItemFilter
ItemMain ->  ItemResult
ItemMain ->  ItemFooter
자식컴포넌트로 값을 보내주는 방식으로 변경

추가 : 로딩바 추가했습니다.
package 수정되었습니다.(협업할땐올리전에 말씀드리고 작업하는걸로 하겠습니다.) 
